### PR TITLE
Restore plugged volume

### DIFF
--- a/res/layout/activity_setup.xml
+++ b/res/layout/activity_setup.xml
@@ -71,6 +71,11 @@
         android:layout_height="wrap_content"
         android:text="@string/enable_ringer_volume" />
     <CheckBox
+        android:id="@+id/check_box_save_plug_vol"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/save_plug_vol" />
+    <CheckBox
         android:id="@+id/check_box_save_unplug_vol"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -29,4 +29,5 @@
     <string name="ring_vol">Ringer</string>
     <string name="media_vol">Media</string>
     <string name="save_unplug_vol">Save last unplugged volume</string>
+    <string name="save_plug_vol">Save last plugged volume</string>
 </resources>

--- a/src/com/jakebasile/android/hearingsaver/SetupActivity.java
+++ b/src/com/jakebasile/android/hearingsaver/SetupActivity.java
@@ -60,13 +60,13 @@ public final class SetupActivity extends Activity
             (CheckBox)dialogLayout.findViewById(R.id.activity_setup_btenabled);
         final RadioGroup radioGroup =
             (RadioGroup)dialogLayout.findViewById(R.id.radio_group);
-        final CheckBox savePluggedVolCheckBox =
+        final CheckBox saveUnpluggedVolCheckBox =
             (CheckBox)dialogLayout.findViewById(R.id.check_box_save_unplug_vol);
         final RadioButton radioMedia = 
             (RadioButton)dialogLayout.findViewById(R.id.radio_button_media);
         final RadioButton radioRing = 
             (RadioButton)dialogLayout.findViewById(R.id.radio_button_ring);
-        savePluggedVolCheckBox.setOnCheckedChangeListener(new OnCheckedChangeListener()
+        saveUnpluggedVolCheckBox.setOnCheckedChangeListener(new OnCheckedChangeListener()
         {
             @Override
             public void onCheckedChanged(CompoundButton buttonView,
@@ -111,7 +111,7 @@ public final class SetupActivity extends Activity
         
         pluggedBar.setProgress((int)(settings.getPluggedLevel() * 100));
         unpluggedBar.setProgress((int)(settings.getUnpluggedLevel() * 100));
-        savePluggedVolCheckBox.setChecked(settings.getSaveUnplugLevel());
+        saveUnpluggedVolCheckBox.setChecked(settings.getSaveUnplugLevel());
         ringerBox.setOnCheckedChangeListener(new OnCheckedChangeListener()
         {
             @Override

--- a/src/com/jakebasile/android/hearingsaver/SetupActivity.java
+++ b/src/com/jakebasile/android/hearingsaver/SetupActivity.java
@@ -60,12 +60,24 @@ public final class SetupActivity extends Activity
             (CheckBox)dialogLayout.findViewById(R.id.activity_setup_btenabled);
         final RadioGroup radioGroup =
             (RadioGroup)dialogLayout.findViewById(R.id.radio_group);
+        final CheckBox savePluggedVolCheckBox =
+            (CheckBox)dialogLayout.findViewById(R.id.check_box_save_plug_vol);
         final CheckBox saveUnpluggedVolCheckBox =
             (CheckBox)dialogLayout.findViewById(R.id.check_box_save_unplug_vol);
         final RadioButton radioMedia = 
             (RadioButton)dialogLayout.findViewById(R.id.radio_button_media);
         final RadioButton radioRing = 
             (RadioButton)dialogLayout.findViewById(R.id.radio_button_ring);
+        savePluggedVolCheckBox.setOnCheckedChangeListener(new OnCheckedChangeListener()
+        {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView,
+                boolean isChecked)
+            {
+                settings.setSavePlugLevel(isChecked);
+                pluggedBar.setEnabled(!isChecked);
+            }
+        });
         saveUnpluggedVolCheckBox.setOnCheckedChangeListener(new OnCheckedChangeListener()
         {
             @Override
@@ -111,6 +123,7 @@ public final class SetupActivity extends Activity
         
         pluggedBar.setProgress((int)(settings.getPluggedLevel() * 100));
         unpluggedBar.setProgress((int)(settings.getUnpluggedLevel() * 100));
+        savePluggedVolCheckBox.setChecked(settings.getSavePlugLevel());
         saveUnpluggedVolCheckBox.setChecked(settings.getSaveUnplugLevel());
         ringerBox.setOnCheckedChangeListener(new OnCheckedChangeListener()
         {

--- a/src/com/jakebasile/android/hearingsaver/UnplugReceiver.java
+++ b/src/com/jakebasile/android/hearingsaver/UnplugReceiver.java
@@ -108,6 +108,16 @@ public class UnplugReceiver extends BroadcastReceiver
             // unplugged.
                 case 0:
                 {
+                    if(settings.getSavePlugLevel())
+                    {
+                        float oldVol =
+                            (float)am.getStreamVolume(AudioManager.STREAM_MUSIC) / maxVol;
+                        float oldVolRinger =
+                            (float)am.getStreamVolume(AudioManager.STREAM_RING) /
+                                maxVolRinger;
+                        settings.setPluggedLevel(oldVol);
+                        settings.setPluggedLevelRinger(oldVolRinger);
+                    }
                     int newVol = (int)(maxVol * settings.getUnpluggedLevel());
                     int newVolRinger = (int)(maxVolRinger *
                         settings.getUnpluggedLevelRinger());

--- a/src/com/jakebasile/android/hearingsaver/VolumeSettings.java
+++ b/src/com/jakebasile/android/hearingsaver/VolumeSettings.java
@@ -35,6 +35,8 @@ final class VolumeSettings
 
     private static final String ENABLED = "enabled";
 
+    private static final String SAVE_PLUG_LEVEL = "save_plug_level";
+
     private static final String SAVE_UNPLUG_LEVEL = "save_unplug_level";
 
     private static final String BLUETOOTH_DETECTION = "btDetection";
@@ -129,6 +131,18 @@ final class VolumeSettings
     {
         Editor editPrefs = getSharedPrefs().edit();
         editPrefs.putBoolean(RINGER_CONTROL, enable);
+        editPrefs.commit();
+    }
+
+    public boolean getSavePlugLevel()
+    {
+        return getSharedPrefs().getBoolean(SAVE_PLUG_LEVEL, false);
+    }
+
+    public void setSavePlugLevel(boolean save)
+    {
+        Editor editPrefs = getSharedPrefs().edit();
+        editPrefs.putBoolean(SAVE_PLUG_LEVEL, save);
         editPrefs.commit();
     }
 


### PR DESCRIPTION
The ability to restore unplugged volume is great, but it would make hearing-saver a lot easier to configure if you could also restore the plugged volume. That way, you just adjust your volume and when you plug/unplug hearing-saver automatically saves your volume for when you unplug/plug.

This also resolves issues where the volume sliders in the app don't behave the same as the volume sliders in the system menu (especially what point is vibrate and what point is low volume).
